### PR TITLE
datagrip release 2019.2.3

### DIFF
--- a/com.jetbrains.DataGrip.appdata.xml
+++ b/com.jetbrains.DataGrip.appdata.xml
@@ -39,6 +39,7 @@
   <update_contact>datagrip@jetbrains.com</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release type="stable" date="2019-08-28" version="2019.2.3" />
     <release type="stable" date="2019-08-16" version="2019.2.2" />
     <release type="stable" date="2019-08-01" version="2019.2.1" />
     <release type="stable" date="2019-07-30" version="2019.2.0" />

--- a/com.jetbrains.DataGrip.json
+++ b/com.jetbrains.DataGrip.json
@@ -56,9 +56,9 @@
           "type": "extra-data",
           "filename": "datagrip.tar.gz",
           "only-arches": ["x86_64"],
-          "sha256": "ab12e1187b8b727c444af404cf9b66ba5070d7833e842d7b0e5aa9577ff34bad",
-          "size": 348139268,
-          "url": "https://download.jetbrains.com/datagrip/datagrip-2019.2.2.tar.gz"
+          "sha256": "ec1a777c9d1a2ea56543954a0d48cecbb2b509523cff724db36371219c56f013",
+          "size": 350551317,
+          "url": "https://download.jetbrains.com/datagrip/datagrip-2019.2.3.tar.gz"
         }, {
           "type": "file",
           "path": "com.jetbrains.DataGrip.appdata.xml"


### PR DESCRIPTION
```shell
==> JetBrains DataGrip
Date: 2019-08-28
Version: 2019.2.3
Link: https://download.jetbrains.com/datagrip/datagrip-2019.2.3.tar.gz
Size: 350551317
Checksum: ec1a777c9d1a2ea56543954a0d48cecbb2b509523cff724db36371219c56f013
Upgrade needed – expected: 2019.2.2, actual: 2019.2.3
```