### PR TITLE
datagrip release 2019.2.5

### DIFF
--- a/com.jetbrains.DataGrip.appdata.xml
+++ b/com.jetbrains.DataGrip.appdata.xml
@@ -39,6 +39,7 @@
   <update_contact>datagrip@jetbrains.com</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release type="stable" date="2019-09-26" version="2019.2.5" />
     <release type="stable" date="2019-09-12" version="2019.2.4" />
     <release type="stable" date="2019-08-28" version="2019.2.3" />
     <release type="stable" date="2019-08-16" version="2019.2.2" />

--- a/com.jetbrains.DataGrip.json
+++ b/com.jetbrains.DataGrip.json
@@ -34,9 +34,9 @@
           "type": "extra-data",
           "filename": "datagrip.tar.gz",
           "only-arches": ["x86_64"],
-          "sha256": "c128cc20a90f88598cdf075f432e2c40ce175ded188c22bc35f7cf90b7c3862a",
-          "size": 353348395,
-          "url": "https://download.jetbrains.com/datagrip/datagrip-2019.2.4.tar.gz"
+          "sha256": "f7780ba87e732c9904db0dd5ba2a7f6340e1a8162f16214b61fb520519add9a1",
+          "size": 356008790,
+          "url": "https://download.jetbrains.com/datagrip/datagrip-2019.2.5.tar.gz"
         }, {
           "type": "file",
           "path": "com.jetbrains.DataGrip.appdata.xml"


### PR DESCRIPTION
```shell
==> JetBrains DataGrip
Link: https://download.jetbrains.com/datagrip/datagrip-2019.2.5.tar.gz
Checksum: f7780ba87e732c9904db0dd5ba2a7f6340e1a8162f16214b61fb520519add9a1
Size: 356008790
Version: 2019.2.5
Date: 2019-09-26
Upgrade needed! Flatpak version: 2019.2.4, released version: 2019.2.5
```