### PR TITLE
Register application menu into desktop environment

### DIFF
--- a/com.jetbrains.DataGrip.json
+++ b/com.jetbrains.DataGrip.json
@@ -15,7 +15,8 @@
         "--socket=x11",
         "--talk-name=org.freedesktop.Flatpak",
         "--talk-name=org.freedesktop.Notifications",
-        "--talk-name=org.freedesktop.secrets"
+        "--talk-name=org.freedesktop.secrets",
+        "--talk-name=com.canonical.AppMenu.Registrar"
     ],
     "modules": [
         "shared-modules/libsecret/libsecret.json",


### PR DESCRIPTION
Currently, the application doesn't register the menu into my desktop environment, so I added an additional finish-arg as it was stated in Octave issue https://github.com/flathub/org.octave.Octave/issues/6

Also see https://github.com/flatpak/flatpak/issues/2012 and https://github.com/flathub/com.wire.WireDesktop/issues/3