### PR TITLE
Add release metadata for latest versions

### DIFF
--- a/com.jetbrains.DataGrip.metainfo.xml
+++ b/com.jetbrains.DataGrip.metainfo.xml
@@ -39,6 +39,8 @@
   <update_contact>datagrip@jetbrains.com</update_contact>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="2021.1.1" date="2021-04-29"/>
+    <release version="2021.1" date="2021-04-01"/>
     <release version="2020.3" date="2020-11-25"/>
     <release version="2020.2.3" date="2020-09-17"/>
   </releases>


### PR DESCRIPTION
The version displayed in Flathub is still 2020.3 despite the source being updated to 2021.x