### PR TITLE
Added zypak wrapper

### DIFF
--- a/com.jetbrains.DataGrip.metainfo.xml
+++ b/com.jetbrains.DataGrip.metainfo.xml
@@ -39,6 +39,7 @@
   <update_contact>datagrip@jetbrains.com</update_contact>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="2023.1.1" date="2023-04-12"/>
     <release version="2023.1" date="2023-03-28"/>
     <release version="2022.3.2" date="2022-12-22"/>
   </releases>

--- a/com.jetbrains.DataGrip.metainfo.xml
+++ b/com.jetbrains.DataGrip.metainfo.xml
@@ -39,7 +39,6 @@
   <update_contact>datagrip@jetbrains.com</update_contact>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="2023.1.1" date="2023-04-12"/>
     <release version="2023.1" date="2023-03-28"/>
     <release version="2022.3.2" date="2022-12-22"/>
   </releases>

--- a/com.jetbrains.DataGrip.yaml
+++ b/com.jetbrains.DataGrip.yaml
@@ -72,6 +72,12 @@ modules:
         sha256: cd12a064013ed18e2ee8475e669b9f58db1b225a0144debdb85a68cecddba57f
         url: https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.1.1.tar.bz2
 
+  - name: zypak
+    sources:
+      - type: git
+        tag: v2022.04
+        url: https://github.com/refi64/zypak
+
   - name: datagrip
     buildsystem: simple
     build-commands:
@@ -105,11 +111,7 @@ modules:
         sha256: 47e2bd0ae3e1d3906effc0ca2de1320725714e5672b012d2458d43e45e8ae9f4
         size: 2271
         url: https://resources.jetbrains.com/storage/products/company/brand/logos/DataGrip_icon.svg
-  - name: zypak
-    sources:
-      - type: git
-        url: https://github.com/refi64/zypak
-        tag: v2022.04
+
 runtime: org.freedesktop.Sdk
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk

--- a/com.jetbrains.DataGrip.yaml
+++ b/com.jetbrains.DataGrip.yaml
@@ -105,6 +105,11 @@ modules:
         sha256: 47e2bd0ae3e1d3906effc0ca2de1320725714e5672b012d2458d43e45e8ae9f4
         size: 2271
         url: https://resources.jetbrains.com/storage/products/company/brand/logos/DataGrip_icon.svg
+  - name: zypak
+    sources:
+      - type: git
+        url: https://github.com/refi64/zypak
+        tag: v2022.04
 runtime: org.freedesktop.Sdk
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ export DATAGRIP_JDK
 TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
 export TMPDIR
 
-exec env /app/extra/datagrip/bin/datagrip.sh "$@"
+exec env zypak-wrapper /app/extra/datagrip/bin/datagrip.sh "$@"


### PR DESCRIPTION
Hopefully this is helpful as I'm not familiar with the contribution guidelines of a Flatpak/flathub application.

This PR is in reference to issue #91 and intends to resolve an issue where users are experiencing a crash on start with the latest release 2023.1. It appears the latest Chromium sandbox release now requires Zypak.

https://github.com/flathub/com.jetbrains.PyCharm-Community/pull/534 served as a template for implementing these changes.