### PR TITLE
Moved idea.properties definition to manifest

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -4,5 +4,4 @@ set -o errexit
 
 install --directory --mode=0755 datagrip/
 tar --directory=datagrip/ --extract --file=datagrip.tar.gz --gunzip --strip-components=1
-tee < idea.properties --append datagrip/bin/idea.properties
 rm --force datagrip.tar.gz

--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -4,4 +4,5 @@ set -o errexit
 
 install --directory --mode=0755 datagrip/
 tar --directory=datagrip/ --extract --file=datagrip.tar.gz --gunzip --strip-components=1
+tee < idea.properties --append datagrip/bin/idea.properties
 rm --force datagrip.tar.gz

--- a/com.jetbrains.DataGrip.yaml
+++ b/com.jetbrains.DataGrip.yaml
@@ -1,9 +1,10 @@
 app-id: com.jetbrains.DataGrip
 command: datagrip
 finish-args:
+  - --allow=devel
   - --device=dri
-  - --filesystem=host
   - --filesystem=xdg-run/gnupg:ro
+  - --filesystem=host
   - --filesystem=xdg-run/keyring
   - --share=ipc
   - --share=network
@@ -16,7 +17,6 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.gnome.keyring.SystemPrompter
 modules:
-  - shared-modules/libsecret/libsecret.json
   - name: gcr
     cleanup:
       - /include
@@ -41,6 +41,8 @@ modules:
       - type: archive
         sha256: 29df50974a90987af694c0fb8926a6b366e68cacd8abd813817cfe1eb5d54524
         url: https://download.gnome.org/sources/gcr/3.34/gcr-3.34.0.tar.xz
+
+  - shared-modules/libsecret/libsecret.json
 
   - name: openssh
     buildsystem: simple
@@ -72,12 +74,6 @@ modules:
         sha256: cd12a064013ed18e2ee8475e669b9f58db1b225a0144debdb85a68cecddba57f
         url: https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.1.1.tar.bz2
 
-  - name: zypak
-    sources:
-      - type: git
-        tag: v2022.04
-        url: https://github.com/refi64/zypak
-
   - name: datagrip
     buildsystem: simple
     build-commands:
@@ -104,13 +100,15 @@ modules:
         path: com.jetbrains.DataGrip.desktop
       - type: file
         path: com.jetbrains.DataGrip.metainfo.xml
-      - type: file
-        path: entrypoint.sh
       - type: file # https://www.jetbrains.com/company/brand/#logos-and-icons
         dest-filename: datagrip-icon.svg
         sha256: 47e2bd0ae3e1d3906effc0ca2de1320725714e5672b012d2458d43e45e8ae9f4
         size: 2271
         url: https://resources.jetbrains.com/storage/products/company/brand/logos/DataGrip_icon.svg
+      - type: file
+        path: entrypoint.sh
+      - type: file
+        path: idea.properties
 
 runtime: org.freedesktop.Sdk
 runtime-version: '22.08'

--- a/com.jetbrains.DataGrip.yaml
+++ b/com.jetbrains.DataGrip.yaml
@@ -82,6 +82,7 @@ modules:
       - install -D --mode=0644 --target-directory=/app/share/applications/ com.jetbrains.DataGrip.desktop
       - install -D --mode=0644 --target-directory=/app/share/metainfo/ com.jetbrains.DataGrip.metainfo.xml
       - install -D --mode=0755 apply_extra.sh /app/bin/apply_extra
+      - tee <idea.properties --append ${FLATPAK_DEST}/bin/idea.properties
     sources:
       - type: extra-data
         filename: datagrip.tar.gz

--- a/com.jetbrains.DataGrip.yaml
+++ b/com.jetbrains.DataGrip.yaml
@@ -82,7 +82,7 @@ modules:
       - install -D --mode=0644 --target-directory=/app/share/applications/ com.jetbrains.DataGrip.desktop
       - install -D --mode=0644 --target-directory=/app/share/metainfo/ com.jetbrains.DataGrip.metainfo.xml
       - install -D --mode=0755 apply_extra.sh /app/bin/apply_extra
-      - tee <idea.properties --append ${FLATPAK_DEST}/bin/idea.properties
+      - tee < idea.properties --append /app/bin/idea.properties
     sources:
       - type: extra-data
         filename: datagrip.tar.gz

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ export DATAGRIP_JDK
 TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
 export TMPDIR
 
-exec env zypak-wrapper /app/extra/datagrip/bin/datagrip.sh "$@"
+exec env /app/extra/datagrip/bin/datagrip.sh "$@"

--- a/idea.properties
+++ b/idea.properties
@@ -1,0 +1,8 @@
+
+# =================================================================================================
+#   USER-DEFINED PROPERTIES/SETTINGS
+# =================================================================================================
+
+# Disable Chrome sandboxing due to invalid user and permissions
+# YouTrack issue: https://youtrack.jetbrains.com/issue/IDEA-313202
+ide.browser.jcef.sandbox.enable = false


### PR DESCRIPTION
@x80486 

I encountered an error while trying to install both the build and from source:

```
F: Running /app/bin/apply_extra
/app/bin/apply_extra: line 7: idea.properties: No such file or directory
Error: While trying to apply extra data: apply_extra script failed, exit status 256
error: Failed to install com.jetbrains.DataGrip: While trying to apply extra data: apply_extra script failed, exit status 256
```

I was able to get around it by moving the idea.properties definition to the manifest. Maybe you have a more elegant solution or could explain why it didn't install correctly the first time.